### PR TITLE
fix: float artifacts use float32

### DIFF
--- a/v2/converters/other_types.go
+++ b/v2/converters/other_types.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"strings"
 )
 
 /*
@@ -24,7 +23,7 @@ func DecodeBool(data []byte) bool {
 	return bytes.Compare(data, []byte{1, 1}) == 0
 }
 
-func ConvertBinaryFloat(bytes []byte) float64 {
+func ConvertBinaryFloat(bytes []byte) float32 {
 	if bytes[0]&128 != 0 {
 		bytes[0] = bytes[0] & 127
 	} else {
@@ -34,14 +33,8 @@ func ConvertBinaryFloat(bytes []byte) float64 {
 		bytes[3] = ^bytes[3]
 	}
 	u := binary.BigEndian.Uint32(bytes)
-	x := math.Float32frombits(u)
-	strX := fmt.Sprintf("%v", x)
-	index := strings.LastIndex(strX, ".")
-	if index < 0 {
-		return float64(x)
-	}
-	exp := len(strX) - index - 1
-	return math.Trunc(float64(x)*math.Pow10(exp)) / math.Pow10(exp)
+	// user can cast to float64 on their side if necessary (pass float64 field as parameter for row.Scan method)
+	return math.Float32frombits(u)
 	//test2 := float64(test)
 	//return test2
 	//if u > (1 << 31) {


### PR DESCRIPTION
### Problem

Go-ora types support is very wide and convenient, but i noticed that current implementation of `ConvertBinaryFloat`  leads to loss of accuracy. Please check [ConvertBinaryFloat test](https://github.com/sijms/go-ora/blob/576a11c0240aeeacf72d87dff66c4e4d3cde55d7/v2/converters/other_types_test.go#L21):
- Input: `134.45`
- Expected output: `134.44`

In given case [math.Trunc](https://github.com/sijms/go-ora/blob/576a11c0240aeeacf72d87dff66c4e4d3cde55d7/v2/converters/other_types.go#L44) cuts most of the fractional part (134.44**999** <- these last numbers), which leads to loss of accuracy.

Step by step transformation:

![image](https://github.com/user-attachments/assets/9b0cb0f9-ad29-40e1-a6cc-8e17834cc800)

### Implementation

- Return float32, so user can use correct value
- User still can cast to float64 on their side (pass float64 param to row.Scan method)

 